### PR TITLE
issue 7: fix the bug for LCA with generic tree

### DIFF
--- a/src/main/java/com/adolfoeloy/tree/LowestCommonAncestorGenericTree.java
+++ b/src/main/java/com/adolfoeloy/tree/LowestCommonAncestorGenericTree.java
@@ -1,30 +1,39 @@
 package com.adolfoeloy.tree;
 
-import java.util.HashSet;
 import java.util.Set;
 
 public class LowestCommonAncestorGenericTree {
 
-    <T> GenericTreeNode<T> search(GenericTreeNode<T> root, Set<GenericTreeNode<T>> query) {
-        return search(root, query, new HashSet<>());
+    private static class Result<T> {
+        GenericTreeNode<T> lca;
+        int count;
+
+        Result(GenericTreeNode<T> lca, int count) {
+            this.lca = lca;
+            this.count = count;
+        }
     }
 
-    private <T> GenericTreeNode<T> search(
-            GenericTreeNode<T> root,
-            Set<GenericTreeNode<T>> query,
-            HashSet<GenericTreeNode<T>> itemsFound
-    ) {
-        if (root == null) return null;
-        if (query.contains(root)) return root;
+    <T> GenericTreeNode<T> search(GenericTreeNode<T> root, Set<GenericTreeNode<T>> query) {
+        return searchHelper(root, query).lca;
+    }
 
-        for (var param : root.children()) {
-            var result = search(param, query);
-            if (result != null) itemsFound.add(param);
+    private <T> Result<T> searchHelper(
+            GenericTreeNode<T> root,
+            Set<GenericTreeNode<T>> query
+    ) {
+        if (root == null) return new Result<>(null, 0);
+        int total = query.contains(root) ? 1 : 0;
+
+        for (var child : root.children()) {
+            var result = searchHelper(child, query);
+            if (result.lca != null) return result;
+            total += result.count;
         }
 
-        if (itemsFound.equals(query)) return root;
+        if (total == query.size()) return new Result<>(root, total);
 
-        return itemsFound.stream().findFirst().orElse(null);
+        return new Result<>(null, total);
     }
 
 }

--- a/src/test/java/com/adolfoeloy/tree/LowestCommonAncestorGenericTreeTest.java
+++ b/src/test/java/com/adolfoeloy/tree/LowestCommonAncestorGenericTreeTest.java
@@ -14,9 +14,9 @@ class LowestCommonAncestorGenericTreeTest {
 
     @Test
     void shouldFindLowestCommonAncestorOfTwoEntriesInQuery() {
-        var p = new GenericTreeNode<>(2, List.of());
-        var q = new GenericTreeNode<>(3, List.of());
-        var root = new GenericTreeNode<>(1, List.of(p, q));
+        var p = node(2);
+        var q = node(3);
+        var root = node(1, List.of(p, q));
 
         var result = subject.search(root, Set.of(p, q));
 
@@ -25,9 +25,9 @@ class LowestCommonAncestorGenericTreeTest {
 
     @Test
     void shouldFindLowestCommonAncestorWithOneEntryAsLCA() {
-        var p = new GenericTreeNode<>(2, List.of());
-        var q = new GenericTreeNode<>(3, List.of());
-        var root = new GenericTreeNode<>(1, List.of(p, q));
+        var p = node(2);
+        var q = node (3);
+        var root = node(1, List.of(p, q));
 
         var result = subject.search(root, Set.of(root, p));
 
@@ -35,32 +35,70 @@ class LowestCommonAncestorGenericTreeTest {
     }
 
     @Test
+    void shouldFindRootAsLCAWhenQueryNodesAreInSeparateSubtrees() {
+        var node5 = node(5);
+        var node2 = node(2);
+        var node3 = node(3, List.of(node5));
+        var root = node(1, List.of(node2, node3));
+
+        var result = subject.search(root, Set.of(node2, node5));
+
+        assertThat(result).isEqualTo(root);
+    }
+
+    @Test
+    void shouldFindDeepestCommonAncestorBetweenTwoSiblings() {
+        var node5 = node(5);
+        var node6 = node(6);
+        var node3 = node(3, List.of(node5, node6));
+        var root = node(1, List.of(node3));
+
+        var result = subject.search(root, Set.of(node5, node6));
+
+        assertThat(result).isEqualTo(node3);
+    }
+
+    @Test
     void shouldFindLowestCommonAncestorOfThreeEntriesInQuery() {
+        // nodes to be queried
         var p = node(9);
         var q = node(10);
         var r = node(13);
 
-        var parent = node(2, List.of(
-                node(4),
-                node(8, List.of(p)),
-                node(5, List.of(
-                        q,
-                        node(11),
-                        node(12, List.of(r))
-                ))
-        ));
+        // intermediate nodes
+        var node4 = node(4);
+        var node8 = node(8, List.of(p));
+        var node11 = node(11);
+        var node12 = node(12, List.of(r));
+        var node5 = node(5, List.of(q, node11, node12));
 
-        var root = node(
-                1, List.of(
-                        parent,
-                        node(3, List.of(
-                                node(6),
-                                node(7)
-                        ))
-                ));
+        var node2 = node(2, List.of(node4, node8, node5));
+        var node6 = node(6);
+        var node7 = node(7);
+        var node3 = node(3, List.of(node7, node6));
+
+        var root = node(1, List.of(node2, node3));
 
         var result = subject.search(root, Set.of(p, q, r));
 
-        assertThat(result).isEqualTo(parent);
+        assertThat(result).isEqualTo(node2);
     }
+
+    @Test
+    void shouldFindLowestCommonAncestorBetweenTwoSiblings() {
+        var node8 = node(8);
+        var node9 = node(9);
+        var node4 = node(4, List.of(node8, node9));
+        var node5 = node(5);
+        var node6 = node(6);
+        var node7 = node(7);
+        var node2 = node(2, List.of(node4, node5));
+        var node3 = node(3, List.of(node6, node7));
+        var root = node(1, List.of(node2, node3));
+
+        var result = subject.search(root, Set.of(node4, node5));
+
+        assertThat(result).isEqualTo(node2);
+    }
+
 }


### PR DESCRIPTION
This PR fixes #7 by using a data-structure to represent the result. This new data-structure contains the LCA found and a counter used to count entries found in the tree. If LCA is found, then set in the result data-structure, the search starts returning the result. Otherwise, the search keep going and incrementing the count whenever an entry from query is found in subtrees.